### PR TITLE
Fix fix accumulation and transfer logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,7 @@ version = "0.1.0"
 [dependencies]
 # # Ensure bincode version is identical to that in SAFE Client Libs and SAFE Network Data.
 bincode = "1.2.1"
-safe-nd = { git = "https://github.com/yoga07/safe-nd", branch = "at2" }
-# safe-nd = { git ="https://github.com/yoga07/safe-nd", branch="at2", features=["simulated-payouts"] }
-# safe-nd = { path="../safe-nd" }
+safe-nd = { git = "https://github.com/maidsafe/safe-nd", branch = "at2" }
 serde = { version = "1.0.97", features = ["derive"] }
 crdts = "4.1.0"
 threshold_crypto = "~0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 [dependencies]
 # # Ensure bincode version is identical to that in SAFE Client Libs and SAFE Network Data.
 bincode = "1.2.1"
-safe-nd = { git = "https://github.com/maidsafe/safe-nd", branch = "at2" }
+safe-nd = { git = "https://github.com/yoga07/safe-nd", branch = "at2" }
 # safe-nd = { git ="https://github.com/yoga07/safe-nd", branch="at2", features=["simulated-payouts"] }
 # safe-nd = { path="../safe-nd" }
 serde = { version = "1.0.97", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ crdts = "4.1.0"
 threshold_crypto = "~0.3.2"
 rand = "~0.6.5"
 itertools = "~0.9.0"
+log = "~0.4.8"
 
 [dev_dependencies]
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -145,6 +145,7 @@ impl Account {
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
     use crdts::Dot;

--- a/src/account.rs
+++ b/src/account.rs
@@ -30,6 +30,7 @@ impl Account {
         }
     }
 
+    /// Returns the ID(PublicKey) for the Account
     pub fn id(&self) -> AccountId {
         self.id
     }

--- a/src/account.rs
+++ b/src/account.rs
@@ -8,7 +8,6 @@
 
 use safe_nd::{AccountId, Error, Money, Result, Transfer, TransferId};
 use std::collections::HashSet;
-
 /// The balance and history of transfers for an account id.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Account {
@@ -55,7 +54,7 @@ impl Account {
     pub fn is_sequential(&self, transfer: &Transfer) -> Result<bool> {
         let id = transfer.id;
         if id.actor != self.id {
-            Err(Error::from("Operation is non-sequential"))
+            Err(Error::from("Account operation is non-sequential"))
         } else {
             match self.debits.last() {
                 None => Ok(id.counter == 0), // if no debits have been made, transfer counter must be 0
@@ -101,14 +100,17 @@ impl Account {
             let _ = self.transfer_ids.insert(transfer.id);
             self.credits.push(transfer);
         } else {
-            panic!("Transfer does not belong to this account")
+            panic!(
+                "Transfer to append does not belong to this account({:?}): transfer: {:?}",
+                self.id, transfer
+            )
         }
     }
 
     /// Test-helper API to simulate Client Transfers.
     #[cfg(feature = "simulated-payouts")]
     pub fn simulated_credit(&mut self, transfer: Transfer) {
-        if self.id == transfer.id.actor {
+        if self.id == transfer.to {
             match self.balance.checked_add(transfer.amount) {
                 Some(amount) => self.balance = amount,
                 None => panic!("overflow when adding!"),
@@ -116,7 +118,10 @@ impl Account {
             let _ = self.transfer_ids.insert(transfer.id);
             self.credits.push(transfer);
         } else {
-            panic!("Transfer does not belong to this account")
+            panic!(
+                "Credit transfer does not belong to this account({:?}): transfer: {:?}",
+                self.id, transfer
+            )
         }
     }
 
@@ -131,7 +136,10 @@ impl Account {
             let _ = self.transfer_ids.insert(transfer.id);
             self.debits.push(transfer);
         } else {
-            panic!("Transfer does not belong to this account")
+            panic!(
+                "Debit transfer does not belong to this account({:?}): transfer: {:?}",
+                self.id, transfer
+            )
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,7 @@ mod test {
         replica_group: &mut ReplicaGroup,
     ) {
         for replica in &mut replica_group.replicas {
-            let registered = replica.register(debit_proof).unwrap();
+            let registered = replica.register(debit_proof, || true).unwrap();
             replica.apply(ReplicaEvent::TransferRegistered(registered));
         }
     }
@@ -313,7 +313,7 @@ mod test {
             .replicas
             .iter_mut()
             .map(|replica| {
-                let propagated = replica.receive_propagated(debit_proof).unwrap();
+                let propagated = replica.receive_propagated(debit_proof, || None).unwrap();
                 replica.apply(ReplicaEvent::TransferPropagated(propagated.clone()));
                 ReplicaEvent::TransferPropagated(propagated.clone())
             })


### PR DESCRIPTION
Fix validation accumulation.
Fix `apply(transfer)` (`next_debit_version` was not updated).
Negates validation of replica keys (temporarily) during credit/sync with `simulated-payouts` flag
Adds support for `SectionProofChain` checking in safe_vault
Adds tests