### PR TITLE
Separate read write + Fix accumulation and transfer logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ version = "0.1.0"
 # # Ensure bincode version is identical to that in SAFE Client Libs and SAFE Network Data.
 bincode = "1.2.1"
 safe-nd = { git = "https://github.com/maidsafe/safe-nd", branch = "at2" }
-# safe-nd = { git ="https://github.com/yoga07/safe-nd", branch="at2", features=["simulated-payouts"] }
-# safe-nd = { path="../safe-nd" }
 serde = { version = "1.0.97", features = ["derive"] }
 crdts = "4.1.0"
 threshold_crypto = "~0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 [dependencies]
 # # Ensure bincode version is identical to that in SAFE Client Libs and SAFE Network Data.
 bincode = "1.2.1"
-safe-nd = { git = "https://github.com/maidsafe/safe-nd", branch = "at2" }
+safe-nd = { git = "https://github.com/oetyng/safe-nd", branch = "separate_read_write" }
 serde = { version = "1.0.97", features = ["derive"] }
 crdts = "4.1.0"
 threshold_crypto = "~0.3.2"

--- a/src/account.rs
+++ b/src/account.rs
@@ -144,6 +144,7 @@ impl Account {
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
     use crdts::Dot;

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -338,7 +338,7 @@ impl<V: ReplicaValidator> Actor<V> {
         debug!("Applying event {:?}", event);
         match event {
             ActorEvent::TransferInitiated(e) => {
-                self.next_debit_version = e.id().counter;
+                self.next_debit_version = e.id().counter + 1;
             }
             ActorEvent::TransferValidationReceived(e) => {
                 if let Some(_) = e.proof {
@@ -365,7 +365,6 @@ impl<V: ReplicaValidator> Actor<V> {
             ActorEvent::TransferRegistrationSent(e) => {
                 self.account.append(e.debit_proof.signed_transfer.transfer);
                 self.accumulating_validations.clear();
-                self.next_debit_version = self.next_debit_version + 1;
             }
             ActorEvent::TransfersSynched(e) => {
                 for credit in e.credits {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,7 @@ mod test {
         replica_group: &mut ReplicaGroup,
     ) {
         for replica in &mut replica_group.replicas {
-            let registered = replica.register(debit_proof).unwrap();
+            let registered = replica.register(debit_proof, || true).unwrap();
             replica.apply(ReplicaEvent::TransferRegistered(registered));
         }
     }
@@ -313,7 +313,7 @@ mod test {
             .replicas
             .iter_mut()
             .map(|replica| {
-                let propagated = replica.receive_propagated(debit_proof).unwrap();
+                let propagated = replica.receive_propagated(debit_proof, || None).unwrap();
                 replica.apply(ReplicaEvent::TransferPropagated(propagated.clone()));
                 ReplicaEvent::TransferPropagated(propagated.clone())
             })

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -9,7 +9,7 @@
 use super::account::Account;
 use log::debug;
 use safe_nd::{
-    AccountId, DebitAgreementProof, Error, KnownGroupAdded, Money, ReplicaEvent, Result,
+    AccountId, DebitAgreementProof, Error, KnownGroupAdded, Money, PublicKey, ReplicaEvent, Result,
     SignatureShare, SignedTransfer, Transfer, TransferPropagated, TransferRegistered,
     TransferValidated,
 };
@@ -212,11 +212,15 @@ impl Replica {
     }
 
     /// Step 2. Validation of agreement, and order at debit source.
-    pub fn register(&self, debit_proof: &DebitAgreementProof) -> Result<TransferRegistered> {
+    pub fn register<F: FnOnce() -> bool>(
+        &self,
+        debit_proof: &DebitAgreementProof,
+        f: F,
+    ) -> Result<TransferRegistered> {
         debug!("Checking registered transfer");
 
         // Always verify signature first! (as to not leak any information).
-        if !self.verify_registered_proof(debit_proof).is_ok() {
+        if !self.verify_registered_proof(debit_proof, f).is_ok() {
             return Err(Error::InvalidSignature);
         }
 
@@ -241,12 +245,13 @@ impl Replica {
 
     /// Step 3. Validation of DebitAgreementProof, and credit idempotency at credit destination.
     /// (Since this leads to a credit, there is no requirement on order.)
-    pub fn receive_propagated(
+    pub fn receive_propagated<F: FnOnce() -> Option<PublicKey>>(
         &self,
         debit_proof: &DebitAgreementProof,
+        f: F,
     ) -> Result<TransferPropagated> {
         // Always verify signature first! (as to not leak any information).
-        let debiting_replicas = self.verify_propagated_proof(debit_proof)?;
+        let debiting_replicas = self.verify_propagated_proof(debit_proof, f)?;
         let already_exists = match self.accounts.get(&debit_proof.to()) {
             None => false,
             Some(history) => history.contains(&debit_proof.id()),
@@ -297,7 +302,7 @@ impl Replica {
                     Some(account) => account.append(transfer),
                     None => {
                         // Creates if not exists.
-                        let mut account = Account::new(transfer.id.actor);
+                        let mut account = Account::new(transfer.to);
                         account.append(transfer.clone());
                         let _ = self.accounts.insert(transfer.to, account);
                     }
@@ -380,7 +385,11 @@ impl Replica {
 
     /// Verify that this is a valid _registered_
     /// DebitAgreementProof, i.e. signed by our peers.
-    fn verify_registered_proof(&self, proof: &DebitAgreementProof) -> Result<()> {
+    fn verify_registered_proof<F: FnOnce() -> bool>(
+        &self,
+        proof: &DebitAgreementProof,
+        f: F,
+    ) -> Result<()> {
         // Check that the proof corresponds to a public key set of our peers.
         match bincode::serialize(&proof.signed_transfer) {
             Err(_) => Err(Error::NetworkOther("Could not serialise transfer".into())),
@@ -389,6 +398,10 @@ impl Replica {
                 let public_key = safe_nd::PublicKey::Bls(self.peer_replicas.public_key());
                 let result = public_key.verify(&proof.debiting_replicas_sig, &data);
                 if result.is_ok() {
+                    return result;
+                }
+                // Check if proof is signed with an older key
+                if f() {
                     return result;
                 }
 
@@ -400,11 +413,27 @@ impl Replica {
 
     /// Verify that this is a valid _propagated_
     /// DebitAgreementProof, i.e. signed by a group that we know of.
-    fn verify_propagated_proof(&self, proof: &DebitAgreementProof) -> Result<safe_nd::PublicKey> {
+    fn verify_propagated_proof<F: FnOnce() -> Option<PublicKey>>(
+        &self,
+        proof: &DebitAgreementProof,
+        f: F,
+    ) -> Result<PublicKey> {
         // Check that the proof corresponds to a public key set of some Replicas.
         match bincode::serialize(&proof.signed_transfer) {
             Err(_) => Err(Error::NetworkOther("Could not serialise transfer".into())),
             Ok(data) => {
+                // Check if it is from our group.
+                let our_key = safe_nd::PublicKey::Bls(self.peer_replicas.public_key());
+                if our_key.verify(&proof.debiting_replicas_sig, &data).is_ok() {
+                    return Ok(our_key);
+                }
+
+                // Check if it was previously a part of our group
+                if let Some(out_past_key) = f() {
+                    return Ok(out_past_key);
+                }
+
+                // TODO: Check retrospectively(using SectionProofChain) for known groups also
                 // Check all known groups of Replicas.
                 for set in &self.other_groups {
                     let debiting_replicas = safe_nd::PublicKey::Bls(set.public_key());

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -188,7 +188,10 @@ impl Replica {
             }
             Some(value) => {
                 if transfer.id.counter != (value + 1) {
-                    return Err(Error::from(format!("out of order msg, previous count: {:?}", value)));
+                    return Err(Error::from(format!(
+                        "out of order msg, previous count: {:?}",
+                        value
+                    )));
                 }
             }
         }
@@ -429,8 +432,8 @@ impl Replica {
                 }
 
                 // Check if it was previously a part of our group
-                if let Some(out_past_key) = f() {
-                    return Ok(out_past_key);
+                if let Some(our_past_key) = f() {
+                    return Ok(our_past_key);
                 }
 
                 // TODO: Check retrospectively(using SectionProofChain) for known groups also


### PR DESCRIPTION
- Reference safe-nd with separate read write.
- Fix validation accumulation.
- Fix apply(transfer) (next_debit_version was not updated).
- Negates validation of replica keys (temporarily) during credit/sync with simulated-payouts flag
- Adds support for SectionProofChain checking in safe_vault
- Adds tests