### PR TITLE
chore(deps): update to point to renamed xor_name repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ simulated-payouts = ["safe-nd/simulated-payouts"]
 
 [patch.crates-io]
 safe-nd = { git = "https://github.com/maidsafe/safe-nd.git", branch = "master" }
-xor_name = { git = "https://github.com/maidsafe/xor-name.git" }
+xor_name = { git = "https://github.com/maidsafe/xor_name.git" }


### PR DESCRIPTION
Should only be merged once https://github.com/maidsafe/xor-name/pull/43 has been merged & repo renamed to xor_name