### PR TITLE
Expose history API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ version = "0.3.3"
 
 [dependencies]
 bincode = "1.2.1"
-sn_data_types = "~0.14.0"
+# sn_data_types = "~0.14.3"
+sn_data_types = { git = "https://github.com/oetyng/sn_data_types", branch = "remove-msgenvelope" }
 thiserror = "1.0.23"
 crdts = "4.3.0"
 threshold_crypto = "~0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ version = "0.3.3"
 
 [dependencies]
 bincode = "1.2.1"
-# sn_data_types = "~0.14.3"
-sn_data_types = { git = "https://github.com/oetyng/sn_data_types", branch = "remove-msgenvelope" }
+sn_data_types = "~0.15.0"
 thiserror = "1.0.23"
 crdts = "4.3.0"
 threshold_crypto = "~0.4.0"

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -361,21 +361,6 @@ impl<V: ReplicaValidator, S: Signing> Actor<V, S> {
         let debits = self.validate_debits(&history.debits);
         if !credits.is_empty() || !debits.is_empty() {
             Outcome::success(TransfersSynched(ActorHistory { credits, debits }))
-        // let mut wallet = self.wallet.clone();
-        // for credit in credits {
-        //     // append credits _before_ debits
-        //     wallet.apply_credit(credit.signed_credit.credit)?;
-        // }
-        // for proof in debits {
-        //     // append debits _after_ credits
-        //     wallet.apply_debit(proof.signed_debit.debit)?;
-        // }
-        // let snapshot: WalletSnapshot = wallet.into();
-        // self.synch(
-        //     snapshot.balance,
-        //     snapshot.debit_version,
-        //     snapshot.credit_ids,
-        // )
         } else {
             Err(Error::NothingToSync) // TODO: the error is actually that credits and/or debits failed validation..
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,10 +214,6 @@ mod test {
 
         let event = ReplicaEvent::TransferPropagated(sn_data_types::TransferPropagated {
             credit_proof: genesis_credit.clone(),
-            crediting_replica_keys: PublicKey::Bls(
-                genesis_elder.signing.replicas_pk_set().public_key(),
-            ),
-            crediting_replica_sig: genesis_elder.signing.sign_credit_proof(&genesis_credit)?,
         });
         wallet_replica.apply(event)?;
 
@@ -276,10 +272,6 @@ mod test {
         wallet_replica.apply(ReplicaEvent::TransferPropagated(
             sn_data_types::TransferPropagated {
                 credit_proof: genesis_credit.clone(),
-                crediting_replica_keys: PublicKey::Bls(
-                    genesis_elder.signing.replicas_pk_set().public_key(),
-                ),
-                crediting_replica_sig: genesis_elder.signing.sign_credit_proof(&genesis_credit)?,
             },
         ))?;
         let balance = wallet_replica.balance();
@@ -311,10 +303,6 @@ mod test {
         wallet_replica.apply(ReplicaEvent::TransferPropagated(
             sn_data_types::TransferPropagated {
                 credit_proof: genesis_credit.clone(),
-                crediting_replica_keys: PublicKey::Bls(
-                    genesis_elder.signing.replicas_pk_set().public_key(),
-                ),
-                crediting_replica_sig: genesis_elder.signing.sign_credit_proof(&genesis_credit)?,
             },
         ))?;
 
@@ -507,13 +495,8 @@ mod test {
                     .receive_propagated(&credit_proof, || past_key)?
                     .ok_or(Error::UnexpectedOutcome)?;
 
-                let crediting_replica_sig = replica.signing.sign_credit_proof(&credit_proof)?;
                 let propagated = sn_data_types::TransferPropagated {
                     credit_proof: credit_proof.clone(),
-                    crediting_replica_keys: PublicKey::Bls(
-                        replica.signing.replicas_pk_set().public_key(),
-                    ),
-                    crediting_replica_sig,
                 };
                 // then apply to inmem state
                 wallet_replica.apply(ReplicaEvent::TransferPropagated(propagated.clone()))?;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -243,6 +243,7 @@ impl ReplicaSigning {
     }
 
     /// Get the replica's PK set
+    #[allow(unused)]
     pub fn replicas_pk_set(&self) -> &PublicKeySet {
         &self.peer_replicas
     }
@@ -279,16 +280,6 @@ impl ReplicaSigning {
     pub fn sign_validated_credit(&self, credit: &SignedCredit) -> Result<SignatureShare> {
         match bincode::serialize(credit) {
             Err(_) => Err(Error::Serialisation("Could not serialise credit".into())),
-            Ok(data) => Ok(SignatureShare {
-                index: self.key_index,
-                share: self.secret_key.sign(data),
-            }),
-        }
-    }
-
-    pub fn sign_credit_proof(&self, proof: &CreditAgreementProof) -> Result<SignatureShare> {
-        match bincode::serialize(proof) {
-            Err(_) => Err(Error::Serialisation("Could not serialise proof".into())),
             Ok(data) => Ok(SignatureShare {
                 index: self.key_index,
                 share: self.secret_key.sign(data),


### PR DESCRIPTION
Updates how state and history synch work.
Exposes history API.
Removes crediting replica sig from TransferPropagate.