### PR TITLE
chore(deps): fix correct minor version wildcarding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.7.2"
 
 [dependencies]
 bincode = "1.2.1"
-sn_data_types = "~0.18.2"
+sn_data_types = "~0.18"
 thiserror = "1.0.23"
 crdts = "6.3.2"
 threshold_crypto = "~0.4.0"


### PR DESCRIPTION
- As we assume minor versions to not be breaking, we do not need to specify it, and that's why we use the tilde marker in front of the version number.