### PR TITLE
chore(deps): update dt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.7.6"
 
 [dependencies]
 bincode = "1.2.1"
-sn_data_types = "0.19.0"
+sn_data_types = "~0.19.0"
 thiserror = "1.0.23"
 crdts = "6.3.2"
 threshold_crypto = "~0.4.0"


### PR DESCRIPTION
BREAKING CHANGE: sn_data_types has a breaking change. This is a mend commit to get bump of major v, which was left out in previous commit.